### PR TITLE
Misc: Refactor app async handling, update PR message, etc.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,6 @@ module.exports = {
     'func-style': 'off',
     'no-magic-numbers': 'off',
     'valid-jsdoc': 'off',
-    'no-console': 'off'
+    'no-console': ['error', { allow: ['warn', 'error'] }]
   }
 };

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ $ yarn
 Then start the server:
 
 ```sh
-$ yarn start
+$ DEBUG="badges:*" yarn start
 ```
 
 And try out some sample URLs that don't need additional config:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,9 @@ $ yarn
 Then start the server:
 
 ```sh
-$ DEBUG="badges:*" yarn start
+$ yarn start
+# OR, full debug + pretty logging
+$ DEBUG="badges:*" yarn start:dev
 ```
 
 And try out some sample URLs that don't need additional config:
@@ -31,19 +33,23 @@ And try out some sample URLs that don't need additional config:
 
 Some of our API calls utilize secrets stored in AWS as part of the deployment process. You can still develop against these by using your appropriate AWS credentials along with the same start task:
 
-`EXAMPLE_FORTHCOMING`: See [#28](https://github.com/FormidableLabs/badges/issues/28)
-
-<!--
 ```sh
-$ TODO_INSERT_AWS_VAULT_THING \
+$ AWS_REGION=<INSERT_REGION> \
+  aws-vault exec <INSERT_AWS_VAULT_PROFILE> -- \
+  yarn start
+
+# Could look something like
+$ AWS_REGION=us-east-1 \
+  aws-vault exec jane.developer -- \
   yarn start
 ```
+
+(You can provide normal AWS environment variables / local config files for credentials as an alternative, but we recommend `aws-vault` due to the enhanced security of credential use and storage.)
 
 Then try out things like:
 
 - http://127.0.0.1:3000/travis/infernojs/inferno/sauce/Havunen?name=InfernoJS
 - http://127.0.0.1:3000/sauce/Havunen?labels=none
--->
 
 ### Infrastructure / Production
 

--- a/config/default.js
+++ b/config/default.js
@@ -9,6 +9,9 @@ module.exports = {
   sauce: {
     user: 'FormidableLabs'
   },
+  service: {
+    homePage: 'https://formidable.com/open-source/badges'
+  },
   caching: {
     enabled: true,
     browserMaxAge: 30, // 30 seconds

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "compression": "^1.7.4",
     "config": "^3.2.3",
     "express": "^4.17.1",
-    "express-interceptor": "^1.1.1",
     "gzip-size": "^4.0.0",
     "humanize-duration": "^3.21.0",
     "lodash": "^4.17.15",
@@ -41,7 +40,6 @@
     "pretty-bytes": "^4.0.2",
     "request": "^2.88.0",
     "serverless-http": "^2.3.0",
-    "svgo": "^0.7.0",
     "xml2js": "^0.4.22"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "aws-sdk": "^2.544.0",
     "compression": "^1.7.4",
     "config": "^3.2.3",
+    "debug": "^4.1.1",
     "express": "^4.17.1",
     "gzip-size": "^4.0.0",
     "humanize-duration": "^3.21.0",

--- a/scripts/util/pr-comments.js
+++ b/scripts/util/pr-comments.js
@@ -24,9 +24,21 @@ const postPrEnvironmentLink = async ({ name, stage, tier }) => {
   const octokit = await getOctokitClient(name, tier);
 
   const endpoint = `https://${name}-${tier}-${stage}.freetls.fastly.net`;
+  const examples = [
+    '/size/github/FormidableLabs/react-fast-compare/master/index.js',
+    '/size/npm/victory/dist/victory.min.js?gzip=true',
+    '/browsers?firefox=20,26&iexplore=!8,-9,10',
+    '/travis/infernojs/inferno/sauce/Havunen?name=InfernoJS',
+    '/sauce/Havunen?labels=none'
+  ]
+    .map(example => `${endpoint}${example}`)
+    .map(url => `- ${url} [![example](${url})](${url})`)
+    .join('\n');
 
   const body = `
-Deployed PR environment to ${endpoint}!
+Deployed PR environment to ${endpoint}! Here are some suggested testing endpoints:
+
+${examples}
 
 If you are an admin, deploy to production from the [pipeline page in AWS](https://${region}.console.aws.amazon.com/codesuite/codepipeline/pipelines/tf-${name}-${tier}-${stage}/view?region=${region}).`;
 

--- a/scripts/util/pr-comments.js
+++ b/scripts/util/pr-comments.js
@@ -25,14 +25,17 @@ const postPrEnvironmentLink = async ({ name, stage, tier }) => {
 
   const endpoint = `https://${name}-${tier}-${stage}.freetls.fastly.net`;
   const examples = [
-    '/size/github/FormidableLabs/react-fast-compare/master/index.js',
-    '/size/npm/victory/dist/victory.min.js?gzip=true',
-    '/browsers?firefox=20,26&iexplore=!8,-9,10',
-    '/travis/infernojs/inferno/sauce/Havunen?name=InfernoJS',
-    '/sauce/Havunen?labels=none'
+    'size/github/FormidableLabs/react-fast-compare/master/index.js',
+    'size/npm/victory/dist/victory.min.js?gzip=true',
+    'browsers?firefox=20,26&iexplore=!8,-9,10',
+    'travis/infernojs/inferno/sauce/Havunen?name=InfernoJS',
+    'sauce/Havunen?labels=none'
   ]
-    .map(example => `${endpoint}${example}`)
-    .map(url => `- ${url} [![example](${url})](${url})`)
+    .map(example => ({ example, url: `${endpoint}/${example}` }))
+    .map(
+      ({ example, url }) =>
+        `- [\`${example}\`](${url}) [![example](${url})](${url})`
+    )
     .join('\n');
 
   const body = `

--- a/src/cached-request.js
+++ b/src/cached-request.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+const log = require('debug')(`badges:${path.basename(__filename)}`);
 const request = require('request');
 const gzipSize = require('gzip-size');
 const { prettyPrint } = require('./util');
@@ -39,27 +41,23 @@ function cachedRequest(url, options) {
       } else if (size) {
         const isGzipResponse = response.headers['content-encoding'] === 'gzip';
         if (gzip === isGzipResponse && response.headers['content-length']) {
-          console.log('Size request: returning Content-Length.');
+          log('Size request: returning Content-Length.');
           resolve(parseInt(response.headers['content-length'], 10));
         } else if (method === 'HEAD') {
-          console.log(
+          log(
             'Size request made with HEAD, but no Content-Length: returning null.'
           );
           resolve(null);
         } else if (gzip) {
           if (isGzipResponse) {
-            console.log(
-              'Size request received gzip: returning raw response size.'
-            );
+            log('Size request received gzip: returning raw response size.');
             resolve(responseDataSize);
           } else {
-            console.log(
-              'Size request received uncompressed data: running gzip.'
-            );
+            log('Size request received uncompressed data: running gzip.');
             resolve(gzipSize(body));
           }
         } else {
-          console.log('Size request: returning body length.');
+          log('Size request: returning body length.');
           resolve(body.length);
         }
       } else if (resolveHeaders) {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@
 const PORT = process.env.PORT || 3000;
 const HOST = process.env.SERVER_HOST || '0.0.0.0';
 
+const { basename } = require('path');
+const log = require('debug')(`badges:${basename(__filename)}`);
 const _ = require('lodash');
 const config = require('config');
 const express = require('express');
@@ -113,12 +115,10 @@ app.get('/', (req, res) => {
   res.redirect(homePage);
 });
 
-// eslint-disable-next-line max-statements,complexity
 app.get(
   '/sauce/:user',
+  // eslint-disable-next-line max-statements,complexity
   asyncMiddleware(async (req, res) => {
-    console.log(`Incoming request from referrer: ${req.get('Referrer')}`);
-
     const user = req.params.user;
     const build = req.query.build; // If undefined, will try to get the latest.
 
@@ -170,9 +170,8 @@ app.get('/travis.org/*', (req, res, next) => {
 
 app.get(
   '/travis/:user/:repo',
+  // eslint-disable-next-line max-statements
   asyncMiddleware(async (req, res) => {
-    console.log(`Incoming request from referrer: ${req.get('Referrer')}`);
-
     const user = req.params.user;
     const repo = req.params.repo;
     const endpoint = res.locals.travisEndpoint || undefined;
@@ -208,8 +207,6 @@ app.get(
 app.get(
   '/travis/:user/:repo/sauce/:sauceUser?',
   asyncMiddleware(async (req, res) => {
-    console.log(`Incoming request from referrer: ${req.get('Referrer')}`);
-
     const { user, repo } = req.params;
     const endpoint = res.locals.travisEndpoint || undefined;
     const sauceUser = req.params.sauceUser || user;
@@ -235,8 +232,6 @@ app.get(
 app.get(
   '/size/:source/*',
   asyncMiddleware(async (req, res) => {
-    console.log(`Incoming request from referrer: ${req.get('Referrer')}`);
-
     const source = req.params.source;
     const path = req.params[0];
     const color = req.query.color || 'brightgreen';
@@ -267,8 +262,6 @@ app.get(
 app.get(
   '/browsers',
   asyncMiddleware(async (req, res) => {
-    console.log(`Incoming request from referrer: ${req.get('Referrer')}`);
-
     const browsers = {};
     _.forEach(BROWSERS, (value, browser) => {
       const versionNumbers = (req.query[browser] || '').split(',');
@@ -327,8 +320,7 @@ if (require.main === module) {
     () => {
       const { address, port } = server.address();
 
-      // eslint-disable-next-line no-console
-      console.log(`Server started at http://${address}:${port}`);
+      log(`Server started at http://${address}:${port}`);
     }
   );
 }

--- a/src/size.js
+++ b/src/size.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+const log = require('debug')(`badges:${path.basename(__filename)}`);
 const { cachedRequest, ONE_HOUR, ONE_MINUTE } = require('./cached-request');
 const prettyBytes = require('pretty-bytes');
 
@@ -21,9 +23,7 @@ function getFileSize(url, options = {}) {
         if (bytes) {
           return bytes;
         }
-        console.log(
-          'Could not determine size from HEAD request; fetching body.'
-        );
+        log('Could not determine size from HEAD request; fetching body.');
         return cachedRequest(
           url,
           {

--- a/src/text.js
+++ b/src/text.js
@@ -19,7 +19,6 @@ if (require.main === module) {
     'Microsoft Internet Explorer',
     'Safari'
   ];
-  TEST_STRINGS.forEach(str => {
-    console.log(`${str} [${measureTextWidth(str)}]`);
-  });
+  // eslint-disable-next-line no-console
+  TEST_STRINGS.forEach(str => console.log(`${str} [${measureTextWidth(str)}]`));
 }

--- a/src/travis.js
+++ b/src/travis.js
@@ -118,23 +118,6 @@ class TravisClient {
   }
 }
 
-if (require.main === module) {
-  const onError = err => {
-    console.error(err);
-    // eslint-disable-next-line no-process-exit
-    process.exit(1);
-  };
-  const travis = new TravisClient('exogen', 'script-atomic-onload');
-  travis
-    .getLatestBranchBuild()
-    // eslint-disable-next-line promise/always-return
-    .then(build => {
-      console.log(`Got build ${build.build.id} (#${build.build.number}).`);
-      console.log(JSON.stringify(build, null, 2));
-    })
-    .catch(onError);
-}
-
 module.exports = {
   TravisClient,
   TRAVIS_ORG_ENDPOINT,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,7 +1505,7 @@ debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,7 +1071,7 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^1.0.0, chalk@^1.1.3:
+chalk@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1146,12 +1146,6 @@ ci-info@^1.5.0, ci-info@^1.6.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
   integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
 
-clap@^1.0.9:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/clap/-/clap-1.1.3.tgz#b3bd36e93dd4cbfb395a3c26896352445265c05b"
-  dependencies:
-    chalk "^1.1.3"
-
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -1196,12 +1190,6 @@ clone@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
 
-coa@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.1.tgz#7f959346cfc8719e3f7233cd6852854a7c67d8a3"
-  dependencies:
-    q "^1.1.2"
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -1235,10 +1223,6 @@ colors@1.3.x:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
   integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
-
-colors@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -1475,13 +1459,6 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
-
-csso@~2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-2.3.2.tgz#ddd52c587033f49e94b71fc55569f252e8ff5f85"
-  dependencies:
-    clap "^1.0.9"
-    source-map "^0.5.3"
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -2180,7 +2157,7 @@ espree@^6.1.1:
     acorn-jsx "^5.0.2"
     eslint-visitor-keys "^1.1.0"
 
-esprima@^2.6.0, esprima@^2.7.0:
+esprima@^2.7.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
@@ -2310,12 +2287,6 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-express-interceptor@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/express-interceptor/-/express-interceptor-1.2.0.tgz#33460a8e11dce7e5a022caf555d377e45ddb822a"
-  dependencies:
-    debug "^2.2.0"
 
 express@^4.16.3, express@^4.17.1:
   version "4.17.1"
@@ -3698,13 +3669,6 @@ js-yaml@^3.13.1, js-yaml@^3.8.3:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@~3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
-
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -4263,7 +4227,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -5084,7 +5048,7 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-q@^1.0.1, q@^1.1.2:
+q@^1.0.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
@@ -5602,7 +5566,7 @@ sax@1.2.1:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
   integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
 
-sax@>=0.6.0, sax@~1.2.1:
+sax@>=0.6.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
@@ -5904,7 +5868,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-"source-map@>= 0.1.2", source-map@^0.5.3, source-map@^0.5.6:
+"source-map@>= 0.1.2", source-map@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -6204,18 +6168,6 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
-
-svgo@^0.7.0:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
-  dependencies:
-    coa "~1.0.1"
-    colors "~1.1.2"
-    csso "~2.3.1"
-    js-yaml "~3.7.0"
-    mkdirp "~0.5.1"
-    sax "~1.2.1"
-    whet.extend "~0.9.9"
 
 table@^5.2.3:
   version "5.4.1"
@@ -6769,10 +6721,6 @@ whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
-
-whet.extend@~0.9.9:
-  version "0.9.9"
-  resolved "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"
 
 which@^1.2.9:
   version "1.2.14"


### PR DESCRIPTION
## Big
- Major refactor of the application code to `async` pattern with actual error handling. Previously any errors were just swallowed in promises due to promise coding and cache header setting. This resulted in a given page hanging instead of throwing an error page. Fixes #27 
- Move all `res.*` setting methods to one location that occurs _after_ we do all the stuff that can throw exceptions. Even with proper `async` error handling if you set headers the responses will still hang.
- Add localdev example for using prod secrets. Fixes #28 
- Redirect index page to Formidable lander. Fixes #23 
- Update PR comment to hopefully 🤞 give us clickable + SVG example badges!

## Small
- Replace `console.log` with `debug` for localdev
- Remove referrer logging.
- Remove old `require.main` script testing that applied against old project.

## Review note

The diff for `src/index.js` is collapsed because it's large. Unfortunately, it's also the most important thing to review because I changed so much!

/cc @tptee @exogen @formidableamy 