### PR TITLE
Infra: Only create S3 artifacts bucket for non-prod.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+## UNRELEASED
+
+- Infra: Only create S3 artifacts bucket for non-`prod`.
+
 ## 7.5.1
 
 - Infra: Add tags to all Terraform resources that could add them.

--- a/terraform/admin/ci.tf
+++ b/terraform/admin/ci.tf
@@ -5,6 +5,8 @@ locals {
 }
 
 resource "aws_s3_bucket" "artifacts" {
+  count = local.ci_count
+
   bucket        = "${local.prefix}-artifacts-${local.account_id}"
   acl           = "private"
   force_destroy = true


### PR DESCRIPTION
## Work
- Implement change

## Infrastructure
- Ran `apply` for `nonprod` and found no changes as expected.
- Ran `apply` for `prod` and deleted `aws_s3_bucket.artifacts[0]` resource as expected.