### PR TITLE
update ci scripts to use tf lock timeout

### DIFF
--- a/scripts/cd.js
+++ b/scripts/cd.js
@@ -43,6 +43,7 @@ const main = async () => {
     [
       'apply',
       '-auto-approve',
+      '-lock-timeout=5m',
       '--terragrunt-non-interactive',
       '--terragrunt-working-dir',
       'terraform/app'

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -51,17 +51,21 @@ const slsDeployWithRetry = async (attempt = 0) => {
     await wait(SLS_DEPLOY_RETRY_SLEEP_INTERVAL);
   }
 
-  const { stdout, stderr } = await execa(
-    'yarn',
-    ['sls', 'deploy', '--package', '.serverless'],
-    execaOpts
-  );
-  const out = `${stdout} ${stderr}`;
-  if (
-    out.includes('UPDATE_IN_PROGRESS') ||
-    out.includes('UPDATE_COMPLETE_CLEANUP_IN_PROGRESS')
-  ) {
-    await slsDeployWithRetry(attempt + 1);
+  try {
+    await execa(
+      'yarn',
+      ['sls', 'deploy', '--package', '.serverless'],
+      execaOpts
+    );
+  } catch (err) {
+    if (
+      err.all.includes('UPDATE_IN_PROGRESS') ||
+      err.all.includes('UPDATE_COMPLETE_CLEANUP_IN_PROGRESS')
+    ) {
+      await slsDeployWithRetry(attempt + 1);
+    } else {
+      throw err;
+    }
   }
 };
 

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -22,6 +22,18 @@ const execaOpts = {
   }
 };
 
+const getTerragruntArgs = (command, workingDir) =>
+  [].concat(
+    command,
+    [
+      '-auto-approve',
+      '-lock-timeout=5m',
+      '--terragrunt-non-interactive',
+      '--terragrunt-working-dir'
+    ],
+    workingDir
+  );
+
 const create = async () => {
   // If testing locally, removes any leftover artifact folders to ensure that
   // they don't get repackaged during `sls package`.
@@ -42,13 +54,7 @@ const create = async () => {
   // Apply any Terraform that accommodates this stage.
   await execa(
     'terragrunt',
-    [
-      'apply',
-      '-auto-approve',
-      '--terragrunt-non-interactive',
-      '--terragrunt-working-dir',
-      'terraform/app'
-    ],
+    getTerragruntArgs('apply', 'terraform/app'),
     execaOpts
   );
 
@@ -64,13 +70,7 @@ const create = async () => {
   // Create the CD pipeline for deploying this PR to production.
   await execa(
     'terragrunt',
-    [
-      'apply',
-      '-auto-approve',
-      '--terragrunt-non-interactive',
-      '--terragrunt-working-dir',
-      'terraform/cd'
-    ],
+    getTerragruntArgs('apply', 'terraform/cd'),
     execaOpts
   );
 
@@ -86,26 +86,14 @@ const destroy = async () => {
   // Destroy the CD pipeline for this PR.
   await execa(
     'terragrunt',
-    [
-      'destroy',
-      '-auto-approve',
-      '--terragrunt-non-interactive',
-      '--terragrunt-working-dir',
-      'terraform/cd'
-    ],
+    getTerragruntArgs('destroy', 'terraform/cd'),
     execaOpts
   );
 
   // Destroy any Terraform accommodating this stage.
   await execa(
     'terragrunt',
-    [
-      'destroy',
-      '-auto-approve',
-      '--terragrunt-non-interactive',
-      '--terragrunt-working-dir',
-      'terraform/app'
-    ],
+    getTerragruntArgs('destroy', 'terraform/app'),
     execaOpts
   );
 

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -32,7 +32,7 @@ const isHeadCommitOfPR = async () => {
     '-H',
     '"Authorization:',
     'token',
-    'af44915f4ca561674d3948c511da4290d69a4c4d"',
+    `${process.env.GITHUB_TOKEN}"`,
     `https://api.github.com/repos/FormidableLabs/badges/pulls/${prNumber}/commits`
   ]);
 

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -52,11 +52,16 @@ const slsDeployWithRetry = async (attempt = 0) => {
   }
 
   try {
-    await execa(
+    const subprocess = execa(
       'yarn',
       ['sls', 'deploy', '--package', '.serverless'],
-      execaOpts
+      { ...execaOpts, stdio: 'pipe', all: true }
     );
+
+    subprocess.stdout.pipe(process.stdout);
+    subprocess.stderr.pipe(process.stderr);
+
+    await subprocess;
   } catch (err) {
     if (
       err.all.includes('UPDATE_IN_PROGRESS') ||

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -14,7 +14,7 @@ const stage =
 const shouldDestroy =
   process.env.CODEBUILD_WEBHOOK_EVENT === 'PULL_REQUEST_MERGED';
 
-const SLS_DEPLOY_RETRY_MAX_ATTEMPTS = 2;
+const SLS_DEPLOY_RETRY_MAX_ATTEMPTS = 5;
 const SLS_DEPLOY_RETRY_SLEEP_INTERVAL = 60 * 1000;
 
 const execaOpts = {
@@ -41,7 +41,7 @@ const getTerragruntArgs = (command, workingDir) =>
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const slsDeployWithRetry = async (attempt = 0) => {
-  if (attempt === SLS_DEPLOY_RETRY_MAX_ATTEMPTS) {
+  if (attempt > SLS_DEPLOY_RETRY_MAX_ATTEMPTS) {
     throw new Error('Reached max retries for sls deploy. Giving up...');
   }
 


### PR DESCRIPTION
Fixes #40 

By using lock timeout we can serialize TF operations on PRs where two or more commits are pushed close together. Adjust the timeout above 5 minutes if problem still appears.

On trying to reproduce the problem it seems conflicts between parallel sls deploys are a bigger issue. I added a sls retry function to do a few retries of sls deploy.

In testing I see a race condition where the order of running sls deploy may not be in the same order as commits are pushed. So this race condition may lead to an older commit being ultimately deployed to the PR env instead of the most recent commit. I believe this problem already exists in the repo. However this PR may make it worse.

The `empty1` and `empty2` commits below  show the best outcome. `empty2` was retries b/c the cloudformation stack was in an updating state from `empty1`. You can see in `empty2` logs.

```
Serverless: Packaging service... 
$ /codebuild/output/src992403889/src/github.com/FormidableLabs/badges/node_modules/.bin/sls deploy --package .serverless 
Serverless: Uploading CloudFormation file to S3... 
Serverless: Uploading artifacts... 
Serverless: Uploading service sls-badges-nonprod.zip file to S3 (12.63 MB)... 
Serverless: Validating template... 
Serverless: Updating Stack... 
  
  Serverless Error --------------------------------------- 
  
  Stack:arn:aws:cloudformation:us-east-1:819013376994:stack/sls-badges-nonprod-pr45/328ef9a0-28f9-11ea-9b35-0a522351f81e is in UPDATE_IN_PROGRESS state and can not be updated. 
  
  Get Support -------------------------------------------- 
     Docs:          docs.serverless.com 
     Bugs:          github.com/serverless/serverless/issues 
     Issues:        forum.serverless.com 
  
  Your Environment Information --------------------------- 
     Operating System:          linux 
     Node Version:              10.16.3 
     Framework Version:         1.59.2 
     Plugin Version:            3.2.5 
     SDK Version:               2.0.3 
     Components Core Version:   1.0.0 
     Components CLI Version:    1.4.0 
  
error Command failed with exit code 1. 
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. 
Waiting to retry sls deploy... 
```

And after waiting to retry it then succeeds in the next go through.