### PR TITLE
chore/ci flow race conditions

### DIFF
--- a/terraform/admin/ci.tf
+++ b/terraform/admin/ci.tf
@@ -84,7 +84,7 @@ resource "aws_codebuild_project" "pr_ci" {
 
     environment_variable {
       name  = "TF_CLI_ARGS"
-      value = "-no-color"
+      value = "-no-color -lock-timeout=${var.terraform_lock_timeout_duration}"
     }
   }
 

--- a/terraform/admin/role-ci.tf
+++ b/terraform/admin/role-ci.tf
@@ -50,6 +50,11 @@ resource "aws_iam_role_policy_attachment" "ci_admin" {
   policy_arn = module.serverless.iam_policy_admin_arn
 }
 
+resource "aws_iam_role_policy_attachment" "ci_developer" {
+  role       = aws_iam_role.ci.name
+  policy_arn = module.serverless.iam_policy_developer_arn
+}
+
 resource "aws_iam_role_policy_attachment" "ci_cd_lambdas" {
   role       = aws_iam_role.ci.name
   policy_arn = module.serverless.iam_policy_cd_lambdas_arn

--- a/terraform/admin/terragrunt.hcl
+++ b/terraform/admin/terragrunt.hcl
@@ -48,4 +48,6 @@ inputs = {
 
   root_domain_name         = "formidable.com"
   root_domain_name_zone_id = "Z11V9C4SUTC8Q6"
+
+  terraform_lock_timeout_duration = "20m"
 }

--- a/terraform/admin/variables.tf
+++ b/terraform/admin/variables.tf
@@ -50,6 +50,11 @@ variable "fastly_api_token" {
   default     = ""
 }
 
+variable "terraform_lock_timeout_duration" {
+  description = "The lock timeout for various terraform commands. https://www.terraform.io/docs/commands/init.html#lock-timeout-lt-duration-gt-"
+  default     = "0s"
+}
+
 locals {
   prefix = "tf-${var.service_name}-${var.tier}"
 

--- a/terraform/cd/cd.tf
+++ b/terraform/cd/cd.tf
@@ -185,7 +185,7 @@ resource "aws_codebuild_project" "cd" {
 
     environment_variable {
       name  = "TF_CLI_ARGS"
-      value = "-no-color"
+      value = "-no-color -lock-timeout=${var.terraform_lock_timeout_duration}"
     }
   }
 

--- a/terraform/cd/terragrunt.hcl
+++ b/terraform/cd/terragrunt.hcl
@@ -33,4 +33,6 @@ inputs = {
     tier = "prod"
     url = "${get_env("SERVICE_NAME", "badges")}.formidable.com",
   }]
+
+  terraform_lock_timeout_duration = "20m"
 }

--- a/terraform/cd/variables.tf
+++ b/terraform/cd/variables.tf
@@ -36,6 +36,11 @@ variable "repo_name" {
   description = "The name of the repo to clone in CI."
 }
 
+variable "terraform_lock_timeout_duration" {
+  description = "The lock timeout for various terraform commands. https://www.terraform.io/docs/commands/init.html#lock-timeout-lt-duration-gt-"
+  default     = "0s"
+}
+
 locals {
   prefix     = "tf-${var.service_name}-${var.tier}-${var.stage}"
   account_id = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
This fixes #40 

Commits pushed close together in time to a PR branch can result in race conditions where the final PR env may not have the code related to the most recent commit. This PR solves this by 
- Adding a check pre sls deploy to only proceed if the commit is the newest commit on the PR branch. This helps serialize the builds and gives priority to the newest commits.

For sls deploy and TF add mechanisms to allow newer commit builds to wait for older builds to finish:
- Adds `waitFor` logic so newer builds will wait for CF operations to be settled before starting sls deploy.
- Adds lock timeout for Terraform.