### PR TITLE
Infra: Update Fastly to BWI POP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changes
 
 ## UNRELEASED
 
+- Bugfix: Allow empty Serverless CloudFormation stack when checking if stack is ready. [#49](https://github.com/FormidableLabs/badges/pull/49)
+- Infra: Update Fastly shield POP to `bwi-va-us`.
 - Deps: Upgrade all dependencies to latest.
 - Infra: Only create S3 artifacts bucket for non-`prod`.
 

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -21,6 +21,8 @@ const shouldDestroy =
 
 const cloudformation = new AWS.CloudFormation();
 
+const { log } = console;
+
 const execaOpts = {
   stdio: 'inherit',
   env: {
@@ -43,21 +45,29 @@ const isHeadCommitOfPR = async () => {
 };
 
 const stackReadyForDeploy = async () => {
+  const stack = `sls-${name}-${tier}-${stage}`;
   const params = {
-    StackName: `sls-${name}-${tier}-${stage}`
+    StackName: stack
   };
 
-  // eslint-disable-next-line no-console
-  console.log('\nChecking if CloudFormation stack is ready...');
+  log('\nChecking if CloudFormation stack is ready...');
 
   await Promise.race(
     [('stackCreateComplete', 'stackUpdateComplete')].map(event =>
       cloudformation.waitFor(event, params).promise()
     )
-  );
+  ).catch(err => {
+    // Allow non-existent CF stack (like on initial PR creation).
+    const originalError = err.originalError || {};
+    if (originalError.message === `Stack with id ${stack} does not exist`) {
+      log('\nCloudFormation stack does not exist (continuing)...');
+      return;
+    }
 
-  // eslint-disable-next-line no-console
-  console.log('CloudFormation stack is ready\n\n');
+    throw err;
+  });
+
+  log('CloudFormation stack is ready\n\n');
 };
 
 const getTerragruntArgs = (command, workingDir) =>

--- a/scripts/ci.js
+++ b/scripts/ci.js
@@ -46,28 +46,26 @@ const isHeadCommitOfPR = async () => {
 
 const stackReadyForDeploy = async () => {
   const stack = `sls-${name}-${tier}-${stage}`;
-  const params = {
-    StackName: stack
-  };
+  let stackMsg = 'is ready';
 
   log('\nChecking if CloudFormation stack is ready...');
 
   await Promise.race(
     [('stackCreateComplete', 'stackUpdateComplete')].map(event =>
-      cloudformation.waitFor(event, params).promise()
+      cloudformation.waitFor(event, { StackName: stack }).promise()
     )
   ).catch(err => {
     // Allow non-existent CF stack (like on initial PR creation).
     const originalError = err.originalError || {};
     if (originalError.message === `Stack with id ${stack} does not exist`) {
-      log('\nCloudFormation stack does not exist (continuing)...');
+      stackMsg = 'does not exist (continuing)';
       return;
     }
 
     throw err;
   });
 
-  log('CloudFormation stack is ready\n\n');
+  log(`CloudFormation stack ${stackMsg}\n\n`);
 };
 
 const getTerragruntArgs = (command, workingDir) =>

--- a/terraform/app/cdn.tf
+++ b/terraform/app/cdn.tf
@@ -34,14 +34,24 @@ resource "fastly_service_v1" "cdn" {
     port    = 443
 
     # Ashburn, Virginia (closest to AWS us-east-1).
+    #
     # NOTE: if using a different region, find the POP on the below map that lives
     # closest to your origin server's region.
+    #
     # From https://docs.fastly.com/guides/performance-tuning/shielding#enabling-shielding :
-    # "Generally, we recommend selecting a datacenter close to your backend.
-    # Doing this allows faster content delivery because we optimize requests between
-    # the shield POP you're selecting (the one close to your server) and the edge POP
-    # (the one close to the user making the request)."
-    shield = "iad-va-us"
+    # > Generally, we recommend selecting a datacenter close to your backend.
+    # > Doing this allows faster content delivery because we optimize requests
+    # > between the shield POP you're selecting (the one close to your server)
+    # > and the edge POP (the one close to the user making the request)."
+    #
+    # To programmatically get a list of POPs, try the following (assumes `jq` installed):
+    #
+    # ```sh
+    # $ ( FASTLY_API_TOKEN=<SNIPPED>; \
+    #     curl -sS https://api.fastly.com/datacenters \
+    #       -H "Fastly-Key: ${FASTLY_API_TOKEN}" |  jq )
+    # ```
+    shield = "bwi-va-us"
 
     use_ssl           = true
     min_tls_version   = "1.2"


### PR DESCRIPTION
From Fastly:

> We are currently in the process of a network migration to a new Ashburn (BWI) datacenter. It has come to our attention that you have service(s) (see attached list) that utilize the Ashburn (IAD) site for shielding purposes that need to be migrated over to Ashburn (BWI).
>
> Our new datacenter for Ashburn (BWI) is online. Note that during the process you should see more edge traffic initially and once the services use the new shielding parameters, a temporary increase in origin traffic will appear.

Work:
- Add code comment about getting DC list
- Update to BWI POP
- Fix bug in stackReadyForDeploy when SLS CF stack doesn't already exist.